### PR TITLE
Fix lists, section title, typos in FAQ

### DIFF
--- a/docs/about/faq.md
+++ b/docs/about/faq.md
@@ -50,6 +50,7 @@ people.
 
 627 Bosch employees are invited to this event because they might be engaged 
 with Embedded IoT Linux.
+
 - 137 accepted the invitation
 - 93 replied tentatively 
 - 338 employees did not response so far
@@ -90,7 +91,8 @@ Borsigstr. 4
  
 ## Badge pick-up (only for Speakers)
 
-Badge Pick-Up will take place in the Foyer on the ground floor during the following hours:
+Badge Pick-Up will take place in the Foyer on the ground floor during the
+following hours:
 
 - Wednesday, July 12, 14:00 - 16:00 
 - Thursday, July 13, 8:00 - 17:00
@@ -103,7 +105,8 @@ The following amenities are on and around the campus.
 - Dinner:  e.g. [Wichtel](https://www.wichtel.de/), for more see [Google Maps](https://www.google.com/maps/search/Restaurants/@48.8158054,9.164201,16z/data=!3m1!4b1!4m7!2m6!3m5!2sBorsigstra%C3%9Fe+4!3s0x4799dbf8d649b777:0x89161a241b27ea21!4m2!1d9.1703535!2d48.8147828?hl=en-GB)
 - Lunch: Bosch canteen at the campus. External guests can load a guest card with
   money. This can be used to pay in the canteen or the shop.
-- At any other time: we plan to organize some beverages for the contributors or visit the shop.
+- At any other time: we plan to organize some beverages for the contributors or
+  visit the shop.
 
 ## Accommodation
 
@@ -119,37 +122,44 @@ the demand separately, because this needs some lead time for the IT department.
 
 Please refer to the [Venue page](../venue.md#parking) for parking information.
 
-## Meeting rooms for talks and presentations, equipment:
+## Meeting room equipment (talks and presentations):
 
-For all rooms we provide a cinema layout.  
+For all rooms we provide a cinema layout.
+
 - Room/Sizi 2: 30 seats
 - Room/Sizi 5: 50 seats
 - Room/Sizi 7: 25 seats
 
-1 desk for presentation and a specified number of attendee seats. For the presenter 
-there is a beamer or screen available. The connection can be made via HDMI or 
-Mira Cast (which requires Windows 10). Guest wireless LAN is available at any 
-place during the conference. Furthermore 1 phone hub is at the speakers desk.
+1 desk for presentation and a specified number of attendee seats. For the
+presenter there is a beamer or screen available. The connection can be made via
+HDMI or Mira Cast (which requires Windows 10). Guest wireless LAN is available
+at any place during the conference. Furthermore 1 phone hub is at the speakers
+desk.
 
-In general, a recording of pictures and tone shall be considered. However, we do not 
-have a technical solution yet. Possibilities are to be checked by us in the near future. 
+In general, a recording of pictures and tone shall be considered. However, we do
+not have a technical solution yet. Possibilities are to be checked by us in the
+near future. 
 
 
 
 ## Auditorium equipment (keynotes and market place)
 
 For a market place (approximately 8 m²) additionally we organize the following
-basics: office table (160x80 cm) or high table, electricity (230V, 6A), 2 chairs.
-On top of that, we provide a meta board, which can carry printouts on both sides. An 
-example of such a board can be found [here](https://eventura.net/mietwelt-shop/moebel-zubehoer/konferenz-bueromoebel/2136/metaplan-pinnwand-franken-grau-tafelmasse-h150cm-x-b-120cm). The provided meta board will have comparable dimensions and material.
+basics: office table (160x80 cm) or high table, electricity (230V, 6A), 2
+chairs. On top of that, we provide a meta board, which can carry printouts on
+both sides. An example of such a board can be found
+[here](https://eventura.net/mietwelt-shop/moebel-zubehoer/konferenz-bueromoebel/2136/metaplan-pinnwand-franken-grau-tafelmasse-h150cm-x-b-120cm).
+The provided meta board will have comparable dimensions and material.
 
-Any additional equipment requests are to be addressed separately to the [conference organization team](../contact.md).
-It is possible to send material in parcels of normal size to a postal address of 
-the location. The post office of the location is in a different building, hence we 
-need to take care about fetching your parcels from there. Please get in contact with
-the [conference organization team](../contact.md) to what extend you want to ship upfront.
+Any additional equipment requests are to be addressed separately to the
+[conference organization team](../contact.md). It is possible to send material
+in parcels of normal size to a postal address of the location. The post office
+of the location is in a different building, hence we need to take care about
+fetching your parcels from there. Please get in contact with the [conference
+organization team](../contact.md) to what extend you want to ship upfront.
 
-Your booth presentation will be close to some others and shall not interfere (e. g. noise). 
+Your booth presentation will be close to some others and shall not interfere
+(e.g. noise). 
 
 
 


### PR DESCRIPTION
- Add empty line before lists
- Clarify room equipment title
- Fix typos
- Assure line limit of 80 characters