### PR TITLE
Add presentation slides option

### DIFF
--- a/include/presentation.md
+++ b/include/presentation.md
@@ -23,4 +23,9 @@
 </p>
 {% endif %}
 
+{%- if metadata.slides -%}
+<h2>Slides</h2>
+[Download slides]({{ metadata.slides }}){ .md-button .md-button--primary }
+{% endif %}
+
 {% endmacro %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,3 +103,5 @@ extra_css:
 
 markdown_extensions:
   - admonition
+  - attr_list
+


### PR DESCRIPTION
- Add option to include link to slides
- Controlled through the keyword "slides" in the presentation macro
- Keyword/value "slides: <link>" can now be added to keynotes and talks