### PR TITLE
Remove AGL from market place booths

### DIFF
--- a/docs/market_place.md
+++ b/docs/market_place.md
@@ -2,7 +2,6 @@
 
 The Market Place will have booths from the following exhibitors:
 
-- AGL
 - Bosch AE
 - Bosch Apertis pro
 - Bosch CoC OSS


### PR DESCRIPTION
AGL will be in Japan that week and cannot service a booth. They asked to be removed from the exhibitor list.