### PR TITLE
Update agenda.md

### DIFF
--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -13,6 +13,7 @@ hide:
 ## Conference agenda
 
 The conference will take place on Thursday, July 13.
+[Talks schedule](https://boschglobal.github.io/embedded-linux/talks/)
 
 ![Conference program](images/program_image.svg)
 


### PR DESCRIPTION
People have trouble finding talks overview. The click on agenda and do not see detailed talk overview. Proposing this shortcut.