### PR TITLE
Add link to talks and keynotes in agenda overview

### DIFF
--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -13,6 +13,8 @@ hide:
 ## Conference agenda
 
 The conference will take place on Thursday, July 13.
+The full list of keynotes can be found [here](https://boschglobal.github.io/embedded-linux/keynotes/)).
+The full list of talks can be found [here](https://boschglobal.github.io/embedded-linux/talks/)).
 
 ![Conference program](images/program_image.svg)
 

--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -13,7 +13,9 @@ hide:
 ## Conference agenda
 
 The conference will take place on Thursday, July 13.
+
 The full list of keynotes can be found [here](https://boschglobal.github.io/embedded-linux/keynotes/)).
+
 The full list of talks can be found [here](https://boschglobal.github.io/embedded-linux/talks/)).
 
 ![Conference program](images/program_image.svg)


### PR DESCRIPTION
When clicking on agenda you cannot view full list of talks and keynotes. This improves this by links