### PR TITLE
Discoverable keynote and talk schedules

### DIFF
--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -14,9 +14,8 @@ hide:
 
 The conference will take place on Thursday, July 13.
 
-The full list of keynotes can be found [here](https://boschglobal.github.io/embedded-linux/keynotes/)).
-
-The full list of talks can be found [here](https://boschglobal.github.io/embedded-linux/talks/)).
+Please refer to the [keynote schedule](keynotes/), the [talk schedule](talks/)
+and the [market place](market_place) for program details.
 
 ![Conference program](images/program_image.svg)
 

--- a/docs/speakers/index.md
+++ b/docs/speakers/index.md
@@ -5,7 +5,7 @@ hide:
 
 # Speakers
 
-This sections features the schedules for: 
+This sections features the following schedules: 
 
-- [Keynotes](../keynotes)
-- [Talks / Presentations](../talks)
+- [Keynotes schedule](../keynotes)
+- [Talks / Presentations schedule](../talks)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,7 @@ nav:
   - Agenda: agenda.md
   - Speakers:
     - speakers/index.md
-    - Keynotes:
+    - Keynotes schedule:
       - keynotes/index.md
       - Bosch: keynotes/bosch.md
       - Linux Foundation: keynotes/linux_foundation.md
@@ -35,7 +35,7 @@ nav:
       - Pengutronix: keynotes/pengutronix.md
       - Siemens: keynotes/siemens.md
       - SUSE: keynotes/suse.md
-    - Talks:
+    - Talks schedule:
       - talks/index.md
       - Bosch TOP97 (1): talks/bosch_top97_1.md
       - Bosch TOP97 (2): talks/bosch_top97_2.md


### PR DESCRIPTION
- Improve wording in the speakers section
- Clarify links on the agenda page