### PR TITLE
Replace email on corporate information page

### DIFF
--- a/docs/about/corporate_information.md
+++ b/docs/about/corporate_information.md
@@ -19,7 +19,7 @@ Dr. Markus Heyn, Dr. Tanja Rückert
 
 **Your contact at Bosch**
 
-<kontakt@bosch.de>  
+[Contact information](/embedded-linux/contact)  
 +49 711 400 40990
 
 **Registration court**


### PR DESCRIPTION
- Replace kontakt@bosch.de with link to contact page