### PR TITLE
Make agenda image items clickable

### DIFF
--- a/docs/agenda.md
+++ b/docs/agenda.md
@@ -18,7 +18,14 @@ Please refer to the [keynote schedule](/embedded-linux/keynotes), the [talk
 schedule](/embedded-linux/talks) and the [market
 place](/embedded-linux/market_place) for program details.
 
-![Conference program](images/program_image.svg)
+<img src="/embedded-linux/images/program_image.svg" alt="Conference program" usemap="#agendamap">
+
+<map name="agendamap">
+  <area shape="rect" coords="75,85,240,138" alt="Keynotes" href="/embedded-linux/keynotes/">
+  <area shape="rect" coords="75,142,238,373" alt="Market Place" href="/embedded-linux/market_place/">
+  <area shape="rect" coords="75,377,240,500" alt="Closing Keynote" href="/embedded-linux/keynotes/bosch/">
+  <area shape="rect" coords="242,135,800,385" alt="Talks" href="/embedded-linux/talks/">
+</map>
 
 ## Dismantling of the exhibition equipment
 


### PR DESCRIPTION
- Add clickable (linked) map regions to the agenda image
- Links to keynotes, talks, market place and closing keynote